### PR TITLE
Install cffi before pyOpenSSL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt install -y \
 && pip install flask \  
 && pip install pymongo \
 && pip install python-crontab \
+&& pip install cffi \
 && pip install pyOpenSSL
 
 # Add geckodriver


### PR DESCRIPTION
## Summary
- install cffi in Dockerfile before installing pyOpenSSL

## Testing
- `pip show cffi | head -n 5`
- `python - <<'PY'
import OpenSSL
print("OpenSSL imported")
PY`

------
https://chatgpt.com/codex/tasks/task_e_6841792a3f18832888f5633ecae9d8d6